### PR TITLE
Add port to README; remove umami example since it causes memory error

### DIFF
--- a/stacks/drupal/README.md
+++ b/stacks/drupal/README.md
@@ -16,13 +16,9 @@ To create the `devbox_drupal` database and example table, you should run:
 
 `mysql -u root < setup_db.sql`
 
-To install Drupal and your dependencies, run `composer install`. The Drupal app will be installed in the `/web` directory, and you can configure your site by visiting `localhost/autoload` in your browser and following the interactive instructions
+To install Drupal and your dependencies, run `composer install`. The Drupal app will be installed in the `/web` directory, and you can configure your site by visiting `localhost:8000/autoload` in your browser and following the interactive instructions
 
 To exit the shell, use `exit`
-
-## Installing the Umami Example 
-
-Run the `install-drupal.sh` script to install the Umami Drupal example. This is a good starter project for trying out and familiarizing yourself with Drupal
 
 ## Configuration
 

--- a/stacks/drupal/devbox.json
+++ b/stacks/drupal/devbox.json
@@ -11,9 +11,6 @@
       "source devbox.d/mysql/set-env.sh"
     ],
     "scripts": {
-      "install_drupal": [
-        "./install-drupal.sh"
-      ],
       "start_services": [
         "devbox.d/mysql/mysql.sh",
         "devbox services start"


### PR DESCRIPTION
For context, when running `devbox run install_drupal`, it's throwing this error:

```
Fatal error: Allowed memory size of 134217728 bytes exhausted (tried to allocate 20480 bytes) in /(...)/drupal/web/core/lib/Drupal/Core/Database/Query/Condition.php on line 405

Fatal error: Allowed memory size of 134217728 bytes exhausted (tried to allocate 40960 bytes) in /(...)/drupal/vendor/composer/ClassLoader.php on line 578
```

So let's remove the broken example for the time bieng.