### PR TITLE
Move initdb call out of init hook; fix some spurious errors

### DIFF
--- a/stacks/lapp-stack/README.md
+++ b/stacks/lapp-stack/README.md
@@ -1,15 +1,17 @@
 # LAPP Stack
 
-This example shows how to build a simple application using Apache, PHP, and PostgreSQL. It uses Devbox Plugins for all 3 packages to simplify configuration
+This example shows how to build a simple application using Apache, PHP, and PostgreSQL. It uses Devbox Plugins for all 3 packages to simplify configuration.
 
 [![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox-examples?folder=stacks/lapp-stack)
 
 ## How to Run
 
-1. To start Apache, PHP-FPM, and Postgres in the background, run `devbox service start`.
-2. Once the services are running, you can start your shell using `devbox shell`. This will also initialize your database by running `initdb` in the init hook.
-3. Create the database and load the test data by using `devbox run create_db`.
-4. You can now test the app using `localhost:8080` to hit the Apache Server. If you want Apache to listen on a different port, you can change the `HTTPD_PORT` environment variable in the Devbox init_hook.
+The following steps may be done inside or outside a devbox shell.
+
+1. Initialize a database by running `devbox run init_db`.
+1. Start Apache, PHP-FPM, and Postgres in the background by run `devbox services start`.
+1. Create the database and load the test data by using `devbox run create_db`.
+1. You can now test the app using `localhost:8080` to hit the Apache Server. If you want Apache to listen on a different port, you can change the `HTTPD_PORT` environment variable in the Devbox init_hook.
 
 ### How to Recreate this Example
 

--- a/stacks/lapp-stack/devbox.json
+++ b/stacks/lapp-stack/devbox.json
@@ -6,11 +6,10 @@
     "apacheHttpd"
   ],
   "shell": {
-    "init_hook": [
-      "initdb"
-    ],
     "scripts": {
+      "init_db": "initdb",
       "create_db": [
+        "dropdb --if-exists devbox_lamp",
         "createdb devbox_lamp",
         "psql devbox_lamp < setup_postgres_db.sql"
       ]

--- a/stacks/lapp-stack/setup_postgres_db.sql
+++ b/stacks/lapp-stack/setup_postgres_db.sql
@@ -1,11 +1,17 @@
 --- You should run this query using psql < setup_db.sql`
 
-DROP DATABASE IF EXISTS devbox_lamp;
-CREATE DATABASE devbox_lamp;
 
-CREATE USER devbox_user WITH PASSWORD 'password';
+DO
+$do$
+BEGIN
+   IF EXISTS (SELECT FROM pg_catalog.pg_roles WHERE  rolname = 'devbox_user') THEN
+      RAISE NOTICE 'Role "my_user" already exists. Skipping.';
+   ELSE
+      CREATE USER devbox_user WITH PASSWORD 'password';
+   END IF;
+END
+$do$;
 
-DROP TABLE IF EXISTS colors;
 CREATE TABLE colors (
 	id SERIAL NOT NULL PRIMARY KEY,
 	name VARCHAR(100) NOT NULL,


### PR DESCRIPTION
Makes a few changes to minimize the number of random errors one encounters while running this example. In particular:
- Moves the call to `initdb` to its own script, so that running `devbox shell` multiple times does not result in a database-already-initialized error.
- Changes `create_db` and `setup_postgres_db.sql` to avoid the following errors on consecutive runs of the script:
```
ERROR:  cannot drop the currently open database
ERROR:  database "devbox_lamp" already exists
ERROR:  role "devbox_user" already exists
```