### PR TITLE
Move initdb outside of init hook; other changes

### DIFF
--- a/stacks/lepp-stack/README.md
+++ b/stacks/lepp-stack/README.md
@@ -8,13 +8,9 @@ An example Devbox shell for NGINX, Postgres, and PHP. This example uses Devbox P
 
 ### Initializing
 
-In this directory, run:
+In this directory, run: `devbox run init_db` to initialize a db.
 
-`devbox shell`
-
-This will run `initdb` automatically on initialization. To start the Servers + Postgres service, run:
-
-`devbox services start`
+To start the Servers + Postgres service, run: `devbox services start`
 
 ### Creating the DB
 

--- a/stacks/lepp-stack/devbox.json
+++ b/stacks/lepp-stack/devbox.json
@@ -6,11 +6,10 @@
     "php81Extensions.pgsql"
   ],
   "shell": {
-    "init_hook": [
-      "initdb"
-    ],
     "scripts": {
+      "init_db": "initdb",
       "create_db": [
+        "dropdb --if-exists devbox_lemp",
         "createdb devbox_lemp",
         "psql devbox_lemp < setup_postgres_db.sql"
       ]

--- a/stacks/lepp-stack/setup_postgres_db.sql
+++ b/stacks/lepp-stack/setup_postgres_db.sql
@@ -1,11 +1,17 @@
 --- You should run this query using psql < setup_db.sql`
 
-DROP DATABASE IF EXISTS devbox_lamp;
-CREATE DATABASE devbox_lamp;
 
-CREATE USER devbox_user WITH PASSWORD 'password';
+DO
+$do$
+BEGIN
+   IF EXISTS (SELECT FROM pg_catalog.pg_roles WHERE  rolname = 'devbox_user') THEN
+      RAISE NOTICE 'Role "my_user" already exists. Skipping.';
+   ELSE
+      CREATE USER devbox_user WITH PASSWORD 'password';
+   END IF;
+END
+$do$;
 
-DROP TABLE IF EXISTS colors;
 CREATE TABLE colors (
 	id SERIAL NOT NULL PRIMARY KEY,
 	name VARCHAR(100) NOT NULL,


### PR DESCRIPTION
This is the same as #39 but for the lepp stack.

Note that the READMEs are in differently style, even though the instructions are basically the same. I didn't change the style here. If we want to unify them, we can do so in a separate PR.