### PR TITLE
[jekyll] Add libffi package to build native extensions

### DIFF
--- a/stacks/jekyll/devbox.json
+++ b/stacks/jekyll/devbox.json
@@ -1,7 +1,8 @@
 {
   "packages": [
     "bundler",
-    "ruby_3_1"
+    "ruby_3_1",
+    "libffi"
   ],
   "shell": {
     "init_hook": [],


### PR DESCRIPTION
Without it, running `devbox run generate` (with unified env) fails to build gems with native extensions. I've spent too much time trying to figure out why `nix-shell` (without flakes) does _not_ need libffi, but `nix print-dev-env` (with flakes) does. Since we're going to move to use flakes anyway, I propose we just add this here and move on.

This does mean some users _may_ have to add an extra package when we move to unified env and flakes, but I think that's an acceptable risk/tradeoff.